### PR TITLE
fix: selection-bg does not work on edge&chrome

### DIFF
--- a/base.css
+++ b/base.css
@@ -105,14 +105,17 @@ pre[class*='language-'] {
 }
 
 /* Selection */
-pre[class*='language-']::selection,
-pre[class*='language-'] ::selection,
-code[class*='language-']::selection,
-code[class*='language-'] ::selection,
 pre[class*='language-']::-moz-selection,
 pre[class*='language-'] ::-moz-selection,
 code[class*='language-']::-moz-selection,
 code[class*='language-'] ::-moz-selection {
+  background: var(--prism-selection-background);
+}
+
+pre[class*='language-']::selection,
+pre[class*='language-'] ::selection,
+code[class*='language-']::selection,
+code[class*='language-'] ::selection {
   background: var(--prism-selection-background);
 }
 


### PR DESCRIPTION
env:
  node: 14.19.1
  sys: win11
  browser: edge，chrome

You can also see this bug on this website: [https://prism-theme-vars.netlify.app/](https://prism-theme-vars.netlify.app/)

![image](https://user-images.githubusercontent.com/39194294/169195219-2393feab-9297-4fc6-9c68-ca8cb8dc2d3a.png)

This should be caused by the writing order of the plural-prefixed, and i saw the right way to write it [prism-one-light.css](https://github1s.com/PrismJS/prism-themes/blob/HEAD/themes/prism-one-light.css#L59):

![image](https://user-images.githubusercontent.com/39194294/169195875-e736f610-0396-4976-af31-0279813a12a5.png)

