### PR TITLE
fix: base selection-bg for light mode code comment

### DIFF
--- a/base.css
+++ b/base.css
@@ -39,7 +39,7 @@
   --prism-line-number: #a5a5a5;
   --prism-line-number-gutter: #333333;
   --prism-line-highlight-background: #eeeeee;
-  --prism-selection-background: #aaaaaa;
+  --prism-selection-background: #dddddd;
   --prism-marker-color: var(--prism-foreground);
   --prism-marker-opacity: 0.4;
   --prism-marker-font-size: 0.8em;

--- a/playground/src/store/themes.json
+++ b/playground/src/store/themes.json
@@ -32,7 +32,7 @@
     "--prism-line-number": "#a5a5a5",
     "--prism-line-number-gutter": "#333333",
     "--prism-line-highlight-background": "#eeeeee",
-    "--prism-selection-background": "#aaaaaa",
+    "--prism-selection-background": "#dddddd",
     "--prism-marker-color": "var(--prism-foreground)",
     "--prism-marker-opacity": "0.4",
     "--prism-marker-font-size": "0.8em",


### PR DESCRIPTION
when I use it, I find that the code comment select can't see clearly in light mode.
<img width="502" alt="image" src="https://user-images.githubusercontent.com/103186898/178690651-0d53e81f-6046-4439-9837-3bff715957f6.png">
So I modify the `--prism-selection-background: #dddddd`,
now show:
<img width="449" alt="image" src="https://user-images.githubusercontent.com/103186898/178691464-445c6a19-b8d3-46ea-b664-2f99578d21dd.png">
