### PR TITLE
fix: css selector typo

### DIFF
--- a/marker.css
+++ b/marker.css
@@ -41,7 +41,7 @@
 }
 
 [class~='language-js']:before,
-[class~='language-typescript']:before {
+[class~='language-javascript']:before {
   content: 'js';
 }
 


### PR DESCRIPTION
When I was using it, I found that my code block was not hint as JavaScript, and I think this is typo